### PR TITLE
Implement CABAL_PROJECT envvar to specify a cabal project file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ env: &env
       # If you have not committed packcheck.sh in your repo at PACKCHECK
       # then it is automatically pulled from this URL.
       PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/harendra-kumar/packcheck"
-      PACKCHECK_GITHUB_COMMIT: "7b3243fbb34d7002039afa23fe6e9e115cf19971"
+      PACKCHECK_GITHUB_COMMIT: "3d48b1711a099fb30fe202b620f6fcf70ed3410b"
 
     docker:
       - image: debian:stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,11 @@
+# packcheck-0.4.2
+# You can use any of the options supported by packcheck as environment
+# variables here.  See https://github.com/composewell/packcheck for all
+# options and their explanation.
+
 version: 2
 
 #-----------------------------------------------------------------------------
-# packcheck-0.4.2
 # Packcheck global environment variables
 #-----------------------------------------------------------------------------
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ env:
   # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
   # then it is automatically pulled from this URL.
   - PACKCHECK_GITHUB_URL="https://raw.githubusercontent.com/harendra-kumar/packcheck"
-  - PACKCHECK_GITHUB_COMMIT="7b3243fbb34d7002039afa23fe6e9e115cf19971"
+  - PACKCHECK_GITHUB_COMMIT="3d48b1711a099fb30fe202b620f6fcf70ed3410b"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # packcheck-0.4.2
 # You can use any of the options supported by packcheck as environment
-# variables here.  See https://github.com/harendra-kumar/packcheck for all
+# variables here.  See https://github.com/composewell/packcheck for all
 # options and their explanation.
+
 # dist: trusty
 dist: xenial
 env:
@@ -102,6 +103,11 @@ matrix:
   # You can specify build flags like this:
   #- env: BUILD=cabal-v2 CABAL_BUILD_OPTIONS="--flags=dev"
   #  addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  # You can use a cabal project file to specify flags like -Werror on per
+  # package basis.
+  - env: BUILD=cabal-v2 CABAL_PROJECT=cabal.project.ci
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
 
   # --------------------------------------------------------------------------
   # GHCJS cabal builds

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Add `CABAL_PROJECT` environment variable to support specifying a cabal
+  project file.
+
 ## 0.4.2
 
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ STACK_BUILD_OPTIONS     : ADDITIONAL stack build command options to append
 --------------------------------------------------
 cabal options
 --------------------------------------------------
+CABAL_PROJECT           : Alternative cabal project config, cannot be a path, just the file name
 CABAL_BUILD_OPTIONS     : ADDITIONAL cabal v2-build options to append to defaults
 CABAL_BUILD_TARGETS     : cabal v2-build targets, default is 'all'
 CABAL_CONFIGURE_OPTIONS : ADDITIONAL cabal v1-configure options to append to defaults

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ environment:
     # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
     # then it is automatically pulled from this URL.
     PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/harendra-kumar/packcheck"
-    PACKCHECK_GITHUB_COMMIT: "7b3243fbb34d7002039afa23fe6e9e115cf19971"
+    PACKCHECK_GITHUB_COMMIT: "3d48b1711a099fb30fe202b620f6fcf70ed3410b"
 
     # Override the temp directory to avoid sed escaping issues
     # See https://github.com/haskell/cabal/issues/5386

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 # packcheck-0.4.2
 # You can use any of the options supported by packcheck as environment
-# variables here.  See https://github.com/harendra-kumar/packcheck for all
+# variables here.  See https://github.com/composewell/packcheck for all
 # options and their explanation.
+
 environment:
     # ------------------------------------------------------------------------
     # Global options, you can use these per build as well

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,0 +1,4 @@
+packages: .
+
+package packcheck
+  ghc-options: -Werror

--- a/packcheck.cabal
+++ b/packcheck.cabal
@@ -25,8 +25,8 @@ description:
   .
   See the README for comprehensive documentation.
 
-homepage:            https://github.com/harendra-kumar/packcheck
-bug-reports:         https://github.com/harendra-kumar/packcheck/issues
+homepage:            https://github.com/composewell/packcheck
+bug-reports:         https://github.com/composewell/packcheck/issues
 license:             BSD3
 license-file:        LICENSE
 tested-with:           GHC==7.10.3
@@ -53,7 +53,7 @@ extra-source-files:
 
 source-repository head
     type: git
-    location: https://github.com/harendra-kumar/packcheck
+    location: https://github.com/composewell/packcheck
 
 flag dev
   description: Development build


### PR DESCRIPTION
Among other things this can be used to specify a project file so that we can use package specific GHC options for building. For example,

```
$ packcheck.sh cabal-v2 CABAL_PROJECT=cabal.project.ci
```