### PR TITLE
Hlint ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ env: &env
       # If you have not committed packcheck.sh in your repo at PACKCHECK
       # then it is automatically pulled from this URL.
       PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/composewell/packcheck"
-      PACKCHECK_GITHUB_COMMIT: "8c2f44a86e45948dc0ac01d125f4f7366dd78402"
+      PACKCHECK_GITHUB_COMMIT: "b92970febc2d66e0ed0202254c97c13392461821"
 
     docker:
       - image: debian:buster

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ env:
   # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
   # then it is automatically pulled from this URL.
   - PACKCHECK_GITHUB_URL="https://raw.githubusercontent.com/composewell/packcheck"
-  - PACKCHECK_GITHUB_COMMIT="8c2f44a86e45948dc0ac01d125f4f7366dd78402"
+  - PACKCHECK_GITHUB_COMMIT="b92970febc2d66e0ed0202254c97c13392461821"
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ stack exec ./packcheck.sh cabal RESOLVER=lts-11
 
 Run hlint commands on the directories `src` and `test`:
 ```
-$ ./packcheck.sh stack HLINT_COMMANDS="hlint lint src; hlint lint test"
+$ ./packcheck.sh cabal-v2 HLINT_OPTIONS="lint" HLINT_TARGETS="src test"
 ```
 
 Send coverage info of the testsuites named `test1` and `test2` to coveralls.io
@@ -295,7 +295,8 @@ COVERAGE                : [y] Just generate coverage information
 --------------------------------------------------
 hlint options
 --------------------------------------------------
-HLINT_COMMANDS          : hlint commands e.g.'hlint lint src; hlint lint test'
+HLINT_OPTIONS           : hlint arguments e.g.'--datadir=. lint'
+HLINT_TARGETS           : target directories to run hlint on e.g. 'src test'
 
 --------------------------------------------------
 Diagnostics options

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ environment:
     # If you have not committed packcheck.sh in your repo at PACKCHECK_LOCAL_PATH
     # then it is automatically pulled from this URL.
     PACKCHECK_GITHUB_URL: "https://raw.githubusercontent.com/composewell/packcheck"
-    PACKCHECK_GITHUB_COMMIT: "8c2f44a86e45948dc0ac01d125f4f7366dd78402"
+    PACKCHECK_GITHUB_COMMIT: "b92970febc2d66e0ed0202254c97c13392461821"
 
     # Override the temp directory to avoid sed escaping issues
     # See https://github.com/haskell/cabal/issues/5386


### PR DESCRIPTION
Add a .hlint.ignore file to ignore files to hlint. This is useful to incrementally hlint files and ratchet them.