### PR TITLE
Ignore implicit cabal.project when using sdist build

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@
 * CABAL_DISABLE_DEPS env var to disable dependencies install by cabal. This can
   be useful when we have dependencies already installed e.g. in a nix shell.
 * Add support for github CI
+* Add packcheck-remote.sh, a wrapper over packcheck that allows you
+  to run packcheck on a remote repository by cloning it locally and
+  optionally merging a branch into another branch (e.g. merging a PR
+  branch into master).
+* Several fixes to make distribution builds safer and with more checks
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Please use `cabal` version 2.4 or later.
 ### Build on CI (Travis/Appveyor/CircleCI)
 To use packcheck for CI testing of your repo:
 
-* Add your package repo to travis/appveyor/circleci
-* Copy
-[.travis.yml](https://github.com/composewell/packcheck/blob/master/.travis.yml),
+* Add your package repo to github/circleci/appveyor/travis as necessary
+* Copy the relevant CI config
+[.github/workflows/packcheck.yml](https://github.com/composewell/packcheck/blob/master/.github/workflows/packcheck.yml),
 [appveyor.yml](https://github.com/composewell/packcheck/blob/master/appveyor.yml),
+[.circleci/config.yml](https://github.com/composewell/packcheck/blob/master/.circleci/config.yml),
 or
-[.circleci/config.yml](https://github.com/composewell/packcheck/blob/master/.circleci/config.yml)
+[.travis.yml](https://github.com/composewell/packcheck/blob/master/.travis.yml),
 to your package repo
 
 CI should work out of the box for most packages. Uncomment the relevant lines
@@ -58,8 +59,8 @@ $ packcheck.sh stack GHCVER=8.6
 | Linux         | OSX       | Windows       |
 |:-------------:|:---------:|:--------------|
 
-| Travis        | Appveyor  | CircleCI      | Local Machine |
-|:-------------:|:---------:|:--------------|:--------------|
+| Github        | Appveyor  | CircleCI      | Travis | Local Machine |
+|:-------------:|:---------:|:--------------|:------:|:--------------|
 
 The script can be easily adapted to any CI with a single line build command.
 

--- a/packcheck.sh
+++ b/packcheck.sh
@@ -317,6 +317,7 @@ short_help() {
   echo "Report issues: https://github.com/composewell/packcheck/issues/new"
 }
 
+# Please add the boolean options to check_boolean_var as well
 show_help() {
   show_step1 "Usage"
   short_help
@@ -381,10 +382,10 @@ show_help() {
   help_envvar CABAL_PROJECT "Alternative cabal project config, cannot be a path, just the file name"
   #help_envvar CABAL_USE_STACK_SDIST "[y] Use stack sdist (to use --pvp-bounds)"
   help_envvar CABAL_BUILD_OPTIONS "ADDITIONAL cabal v2-build options to append to defaults"
-  help_envvar CABAL_DISABLE_DEPS "Do not install dependencies, do not do cabal update"
+  help_envvar CABAL_DISABLE_DEPS "[y] Do not install dependencies, do not do cabal update"
   help_envvar CABAL_BUILD_TARGETS "cabal v2-build targets, default is 'all'"
   help_envvar CABAL_CHECK_RELAX "[y] Do not fail if cabal check fails on the package."
-  help_envvar CABAL_HACKAGE_MIRROR "[y] DESTRUCTIVE! Specify an alternative mirror, modifies the cabal config file."
+  help_envvar CABAL_HACKAGE_MIRROR "DESTRUCTIVE! Specify an alternative mirror, modifies the cabal config file."
 
   show_step1 "Coverage options"
   help_envvar COVERALLS_OPTIONS "hpc-coveralls args and options, usually just test suite names"
@@ -410,6 +411,7 @@ check_all_boolean_vars () {
   check_boolean_var CABAL_USE_STACK_SDIST
   check_boolean_var CABAL_REINIT_CONFIG
   check_boolean_var CABAL_CHECK_RELAX
+  check_boolean_var CABAL_DISABLE_DEPS
   if test -n "$TEST_INSTALL"
   then
     echo "WARNING! TEST_INSTALL is deprecated. Please use ENABLE_INSTALL instead"
@@ -428,6 +430,7 @@ check_all_boolean_vars () {
   check_boolean_var DISABLE_TEST
   check_boolean_var DISABLE_DOCS
   check_boolean_var COVERAGE
+  check_boolean_var CHECK_ENV
 }
 
 show_build_command() {

--- a/packcheck.sh
+++ b/packcheck.sh
@@ -1368,7 +1368,13 @@ create_and_unpack_pkg_dist() {
 install_deps() {
   case "$BUILD" in
     stack) run_verbose_errexit $STACKCMD build $STACK_DEP_OPTIONS ;;
-    cabal-v2) run_verbose_errexit $CABALCMD v2-build $GHCJS_FLAG $CABAL_DEP_OPTIONS $CABAL_BUILD_TARGETS ;;
+    cabal-v2)
+      if test -z "$CABAL_DISABLE_DEPS"
+      then
+        run_verbose_errexit $CABALCMD v2-build $GHCJS_FLAG $CABAL_DEP_OPTIONS $CABAL_BUILD_TARGETS
+      else
+        echo "Skipping. CABAL_DISABLE_DEPS is on."
+      fi ;;
   esac
 }
 
@@ -1599,7 +1605,7 @@ build_compile () {
   fi
 
   show_step "Install package dependencies"
-  test -n "$CABAL_DISABLE_DEPS" || install_deps
+  install_deps
 
   show_step "Build and test"
   build_and_test

--- a/packcheck.sh
+++ b/packcheck.sh
@@ -611,19 +611,19 @@ EOF
 # Stack fetch and install etc.
 #------------------------------------------------------------------------------
 
-ensure_msys_tools() {
-  if [[ `uname` = MINGW* ]]
-  then
-    # retry??
-    for i in "$1"
-    do
-      if test -z "$(which_cmd $i)"
-      then
-        stack exec pacman -- -S --noconfirm $i
-      fi
-    done
-  fi
-}
+#ensure_msys_tools() {
+#  if [[ `uname` = MINGW* ]]
+#  then
+#    # retry??
+#    for i in "$1"
+#    do
+#      if test -z "$(which_cmd $i)"
+#      then
+#        stack exec pacman -- -S --noconfirm $i
+#      fi
+#    done
+#  fi
+#}
 
 fetch_stack_osx() {
   curl -sSkL https://www.stackage.org/stack/osx-x86_64 \

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-15.10
+resolver: lts-17.15
 packages:
 - '.'


### PR DESCRIPTION
Otherwise the build might be passing in the CI and then fail in the distribution because it was depending on some custom options (e.g. a source repository package).

Fixes #39 